### PR TITLE
Fix re.error - global flags not at the start of the expression at position 1

### DIFF
--- a/BermiInflector/Rules/English.py
+++ b/BermiInflector/Rules/English.py
@@ -22,7 +22,7 @@ class English (Base):
         
         rules = [
             ['(?i)(quiz)$' , '\\1zes'],
-            ['^(?i)(ox)$' , '\\1en'],
+            ['(?i)^(ox)$' , '\\1en'],
             ['(?i)([m|l])ouse$' , '\\1ice'],
             ['(?i)(matr|vert|ind)ix|ex$' , '\\1ices'],
             ['(?i)(x|ch|ss|sh)$' , '\\1es'],

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,8 @@
 # twistar: Asynchronous Python ORM
 [![Build Status](https://secure.travis-ci.org/bmuller/twistar.png?branch=master)](https://travis-ci.org/bmuller/twistar) [![Coverage Status](https://coveralls.io/repos/bmuller/twistar/badge.svg?branch=master&service=github)](https://coveralls.io/github/bmuller/twistar?branch=master)
 
+**IMPORTANT:** Twistar project has been officially archived by the owner on Sep 2, 2021. This fork was created to fix critical issues needed for OpenNSA (https://github.com/NORDUnet/opennsa/).
+
 The Twistar Project provides an ActiveRecord (ORM) pattern interface to the Twisted Project's RDBMS library.  This file contains minimal documentation - see the project home page at http://findingscience.com/twistar for more information.
 
 ## Installation


### PR DESCRIPTION
Workaround for https://github.com/NORDUnet/opennsa/issues/48

Using twister 2.0 on Debian 12 (stable) and Python 3.11 gives the following error:
```
$ python3
Python 3.11.2 (main, Nov 30 2024, 21:22:50) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from BermiInflector.Inflector import Inflector
>>> inf = Inflector()
>>> inf.tableize("ServiceConnection")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.11/dist-packages/BermiInflector/Inflector.py", line 78, in tableize
    return self.Inflector.tableize(class_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/BermiInflector/Rules/Base.py", line 80, in tableize
    return self.pluralize(self.underscore(class_name))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/BermiInflector/Rules/English.py", line 66, in pluralize
    match = re.search(rules[rule][0], word, re.IGNORECASE)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/__init__.py", line 176, in search
    return _compile(pattern, flags).search(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/__init__.py", line 294, in _compile
    p = _compiler.compile(pattern, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/_compiler.py", line 743, in compile
    p = _parser.parse(p, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/_parser.py", line 980, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/_parser.py", line 455, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/_parser.py", line 841, in _parse
    raise source.error('global flags not at the start '
re.error: global flags not at the start of the expression at position 1
```

Since the Twistar project has been officially archived, this forked version was created just for the sake of maintaining compatibility with OpenNSA.

## Local tests

Previously, with Python 3.9:
```
$ docker run --rm -it python:3.9  bash
# python3 -m pip install "twistar==2.0"
# python3
>>> from BermiInflector.Inflector import Inflector
>>> inf = Inflector()
>>> inf.tableize("ox")
'oxen'
>>> inf.tableize("foobarox")
'foobaroxes'
>>> inf.tableize("foobar_ox")
'foobar_oxes'
>>>
>>> inf.tableize("Ox")
'oxen'
>>> inf.tableize("AbcOx")
'abc_oxes'
```

Python 3.11 with the fix:
```
$ docker run --rm -it python:3.11  bash
# python3 -m pip install --upgrade https://github.com/amlight/twistar/tarball/fix/re_error_global_flags#egg=twistar
# python3
Python 3.11.11 (main, Jan 14 2025, 05:22:51) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from BermiInflector.Inflector import Inflector
>>> inf = Inflector()
>>> inf.tableize("ox")
'oxen'
>>> inf.tableize("foobarox")
'foobaroxes'
>>> inf.tableize("foobar_ox")
'foobar_oxes'
>>> inf.tableize("Ox")
'oxen'
>>> inf.tableize("AbcOx")
'abc_oxes'
```
